### PR TITLE
default alleles set to not flipped between base and target

### DIFF
--- a/inc/snp.hpp
+++ b/inc/snp.hpp
@@ -138,6 +138,9 @@ public:
         if (loc != -1 && m_loc != -1 && loc != m_loc) {
             return false;
         }
+
+        flipped = false;
+
         if (m_ref == ref) {
             if (!m_alt.empty() && !alt.empty()) {
                 return (m_alt == alt);


### PR DESCRIPTION
It seems that the "flipped" flag needs to be reset for each SNP. thanks.