### PR TITLE
[Fix] <sys/sysctl.h> removed in glibc >= 2.32

### DIFF
--- a/inc/misc.hpp
+++ b/inc/misc.hpp
@@ -48,7 +48,6 @@
 #include "stdlib.h"
 #include "string.h"
 #include <sys/param.h>
-#include <sys/sysctl.h>
 #include <sys/types.h>
 #include <unistd.h>
 #endif


### PR DESCRIPTION
When I compiled PRSice on Linux, I got:
```
In file included from /home/canary/Projects/PRSice/inc/memoryread.hpp:4,
                 from /home/canary/Projects/PRSice/lib/bgen_lib.hpp:10,
                 from /home/canary/Projects/PRSice/src/bgen_lib.cpp:7:
/home/canary/Projects/PRSice/inc/misc.hpp:51:10: fatal error: sys/sysctl.h: No such file or directory
   51 | #include <sys/sysctl.h>
      |          ^~~~~~~~~~~~~~
compilation terminated.
```

Looks like sys/sysctl.h and the sysctl function were removed in glibc 2.32. However, both had been deprecated and hadn't been doing anything for a while. Judging by the header guards in the misc and genotype files, sysctl is only actually called when getting memory on Apple systems. The `#include <sys/sysctl.h>` in misc.hpp seems like an oversight that's only causing an error now because the deprecated code was finally removed.

Just deleting the line fixes the compilation error.